### PR TITLE
refactor: remove unused state and adjust GameCarousel layout

### DIFF
--- a/src/presentation/components/FilterSection/useFilterSection.ts
+++ b/src/presentation/components/FilterSection/useFilterSection.ts
@@ -1,10 +1,8 @@
-import { useState } from 'react';
 import { Platform } from '../../../domain/entities/Game';
 
 interface UseFilterSectionProps {
   selectedPlatform: Platform | null;
   searchQuery: string;
-  setSearchQuery: (query: string) => void;
   filterGamesByPlatform: (platform: Platform) => Promise<void>;
   getGamesByTitle: (query: string) => Promise<void>;
   resetFilters: () => Promise<void>;
@@ -13,7 +11,6 @@ interface UseFilterSectionProps {
 export const useFilterSection = ({
   selectedPlatform,
   searchQuery,
-  setSearchQuery,
   filterGamesByPlatform,
   getGamesByTitle,
   resetFilters,

--- a/src/presentation/components/GameCarousel/GameCarousel.tsx
+++ b/src/presentation/components/GameCarousel/GameCarousel.tsx
@@ -45,9 +45,9 @@ export const GameCarousel: React.FC<GameCarouselProps> = (props) => {
     <div className="relative w-full">
       <div className="overflow-hidden rounded-lg">
         <div className="flex justify-center items-center">
-          <div className="w-full md:w-2/3 lg:w-1/2 px-4">
+          <div className="w-full md:w-2/3 lg:w-1/2 p-4">
             <div
-              className="flex gap-4 transition-transform duration-700 ease-in-out"
+              className="flex transition-transform duration-700 ease-in-out"
               style={{ transform: `translateX(-${currentIndex * 100}%)` }}
             >
               {games.map((item, index) => (


### PR DESCRIPTION
- Remove `setSearchQuery` prop from `useFilterSection` as it is no longer used
- Simplify GameCarousel layout by removing unnecessary `px-4` and `gap-4` classes